### PR TITLE
Root node id update

### DIFF
--- a/src/main/java/opentree/plugins/GoLS.java
+++ b/src/main/java/opentree/plugins/GoLS.java
@@ -105,7 +105,7 @@ public class GoLS extends ServerPlugin {
 			draftTreeInfo.put("draftTreeName",GraphBase.DRAFTTREENAME);
 //			draftTreeInfo.put("lifeNodeID", String.valueOf(ge.findTaxNodeByName("life").getId()));
 			draftTreeInfo.put("startNodeTaxName", String.valueOf(startNode.getProperty(NodeProperty.NAME.propertyName)));
-			draftTreeInfo.put("startNodeOTTId", (Long) startNode.getProperty(NodeProperty.TAX_UID.propertyName));
+			draftTreeInfo.put("startNodeOTTId", Long.valueOf((String) startNode.getProperty(NodeProperty.TAX_UID.propertyName))); //TODO: the taxuids should be stored as longs, not strings... fix this where it happens
 			draftTreeInfo.put("startNodeID", startNode.getId());
 
 		} finally {


### PR DESCRIPTION
The webapp is now able to deal with the new version of the getDraftTreeID service. To finish up this work this branch should be merged to master. Concurrently with this we need to fix the designated root node of the 'big' synthetic tree, which is currently 'life' but ought to be 'cellular organisms'.
