### PR TITLE
Return more MRCA properties (getDraftTreeMRCAForNodes)

### DIFF
--- a/src/main/java/opentree/plugins/GoLS.java
+++ b/src/main/java/opentree/plugins/GoLS.java
@@ -95,12 +95,12 @@ public class GoLS extends ServerPlugin {
 		} else {
 			HashMap<String, Object> vals = new HashMap<String, Object>();
 			vals.put("found_nodes", tips);
-            Node mrca = ge.getDraftTreeMRCAForNodes(tips,false);
+			Node mrca = ge.getDraftTreeMRCAForNodes(tips,false);
 			vals.put("mrca_node_id", mrca.getId());
-            vals.put("mrca_name", mrca.getProperty(NodeProperty.NAME.propertyName));
-            vals.put("mrca_name_unique", mrca.getProperty(NodeProperty.NAME_UNIQUE.propertyName));
-            vals.put("mrca_rank", mrca.getProperty(NodeProperty.TAX_RANK.propertyName));
-            vals.put("mrca_ott_id", mrca.getProperty(NodeProperty.TAX_UID.propertyName));
+			vals.put("mrca_name", mrca.getProperty(NodeProperty.NAME.propertyName));
+			vals.put("mrca_name_unique", mrca.getProperty(NodeProperty.NAME_UNIQUE.propertyName));
+			vals.put("mrca_rank", mrca.getProperty(NodeProperty.TAX_RANK.propertyName));
+			vals.put("mrca_ott_id", mrca.getProperty(NodeProperty.TAX_UID.propertyName));
 			return OTRepresentationConverter.convert(vals);
 		}
 	}


### PR DESCRIPTION
Send more useful properties to the client. For now, this means enough information to link to the MRCA in the synthetic-tree viewer. Addresses #75, but probably not a complete fix **unless** this keeps looking for an ancestor node with an OTT id.
