### PR TITLE
Fix treatment of missing/bad ids in v2 API (should NOT yield 400)

### DIFF
--- a/src/main/java/opentree/plugins/BadIdsException.java
+++ b/src/main/java/opentree/plugins/BadIdsException.java
@@ -1,0 +1,51 @@
+package opentree.plugins;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+import org.neo4j.server.rest.repr.BadInputException;
+
+public class BadIdsException extends BadInputException {
+
+    List<Long> ottIds;
+    List<String> nodeIds;
+    HashMap<String, Object> json;
+
+    public BadIdsException(List<Long> ottIds, List<String> nodeIds, HashMap<String, Object> json) {
+        super("Unrecognized node or taxon id (you should never see this string)");
+        this.ottIds = ottIds;
+        this.nodeIds = nodeIds;
+        this.json = json;
+    }
+
+    public String getMessage() {
+        return multipleBadNodeIDsError(ottIds, nodeIds);
+    }
+
+    private String multipleBadNodeIDsError (List<Long> ottIdsNotInTree, List<String> nodesIDsNotInTree) {
+        String ret = "";
+        if (!ottIdsNotInTree.isEmpty()) {
+            ret = "The following OTT ids were not found: [";
+            for (int i = 0; i < ottIdsNotInTree.size(); i++) {
+                ret += ottIdsNotInTree.get(i);
+                if (i != ottIdsNotInTree.size() - 1) {
+                    ret += ", ";
+                }
+            }
+            ret += "]. ";
+        }
+        if (!nodesIDsNotInTree.isEmpty()) {
+            ret += "The following node ids were not found: [";
+            for (int i = 0; i < nodesIDsNotInTree.size(); i++) {
+                ret += nodesIDsNotInTree.get(i);
+                if (i != nodesIDsNotInTree.size() - 1) {
+                    ret += ", ";
+                }
+            }
+            ret += "]. ";
+        }
+        return ret;
+    }
+
+}

--- a/src/main/java/opentree/plugins/tree_of_life.java
+++ b/src/main/java/opentree/plugins/tree_of_life.java
@@ -137,7 +137,8 @@ public class tree_of_life extends ServerPlugin {
         return OTRepresentationConverter.convert(res);
     }
 
-    private static final List<Integer> empty = new ArrayList<>();
+    // List of OTT or node ids
+    private static final List<Long> empty = new ArrayList<>();
     
     @Description("Get the MRCA of a set of nodes on a the most current draft tree. Accepts "
         + "any combination of node ids and ott ids as input. Returns information about "
@@ -205,49 +206,56 @@ public class tree_of_life extends ServerPlugin {
 
             */
 
-        Map<String, Object> result = v3.doMrca(graphDb, longIdsToStringIds(nodeIDs), ottIDs);
-        Map<String, Object> mrca = (Map<String, Object>)result.get("mrca");
-        Map<String, Object> nearest = (Map<String, Object>)result.get("nearest_taxon");
+        Map<String, Object> v2_result = new HashMap<>(); // the result we're returning
+        Map<String, Object> v3_result; // the result returned by the v3 method
+        try {
+            v3_result = v3.doMrca(graphDb, longIdsToStringIds(nodeIDs), ottIDs);
+            v2_result.put("node_ids_not_in_tree", empty);
+            v2_result.put("ott_ids_not_in_tree", empty);
+        } catch (BadIdsException e) {
+            v3_result = e.json;
+            v2_result.put("node_ids_not_in_tree", stringIdsToLongIds(e.nodeIds));
+            v2_result.put("ott_ids_not_in_tree", e.ottIds);
+        }
 
-        Map<String, Object> res = new HashMap<>();
+        v2_result.put("invalid_node_ids", empty);
+        v2_result.put("invalid_ott_ids", empty);
+        Map<String, Object> mrca = (Map<String, Object>)v3_result.get("mrca");
+        Map<String, Object> nearest = (Map<String, Object>)v3_result.get("nearest_taxon");
+
         String nodeId = (String)(mrca.get("node_id"));
-        res.put("mrca_node_id", stringIdToLongId(nodeId));
-        res.put("invalid_node_ids", empty);
-        res.put("invalid_ott_ids", empty);
-        res.put("node_ids_not_in_tree", empty);
-        res.put("ott_ids_not_in_tree", empty);
-        res.put("tree_id", treeId);
+        v2_result.put("mrca_node_id", stringIdToLongId(nodeId));
+        v2_result.put("tree_id", treeId);
 
         Map<String, Object> taxon = (Map<String, Object>)mrca.get("taxon");
         if (taxon != null) {
-            res.put("ott_id", taxon.get("ott_id"));
+            v2_result.put("ott_id", taxon.get("ott_id"));
             String name = (String)taxon.get("name");
-            res.put("mrca_name", name);
-            res.put("mrca_rank", taxon.get("rank"));
+            v2_result.put("mrca_name", name);
+            v2_result.put("mrca_rank", taxon.get("rank"));
             String uname = (String)taxon.get("unique_name");
             if (uname.equals(name))
-                res.put("mrca_unique_name", "");
+                v2_result.put("mrca_unique_name", "");
             else
-                res.put("mrca_unique_name", uname);
-            res.put("nearest_taxon_mrca_node_id", nodeId);
+                v2_result.put("mrca_unique_name", uname);
+            v2_result.put("nearest_taxon_mrca_node_id", nodeId);
         } else {
-            res.put("ott_id", "null");
-            res.put("mrca_name", "");
-            res.put("mrca_rank", "");
-            res.put("mrca_unique_name", "");
+            v2_result.put("ott_id", "null");
+            v2_result.put("mrca_name", "");
+            v2_result.put("mrca_rank", "");
+            v2_result.put("mrca_unique_name", "");
         }
         if (nearest != null) {
             // What's in all these fields when nearest_taxon == taxon ?
             Object ottId = nearest.get("ott_id");
-            res.put("nearest_taxon_mrca_ott_id", ottId);
-            res.put("nearest_taxon_mrca_name", nearest.get("name"));
-            res.put("nearest_taxon_mrca_rank", nearest.get("rank"));
-            res.put("nearest_taxon_mrca_unique_name", nearest.get("unique_name"));
+            v2_result.put("nearest_taxon_mrca_ott_id", ottId);
+            v2_result.put("nearest_taxon_mrca_name", nearest.get("name"));
+            v2_result.put("nearest_taxon_mrca_rank", nearest.get("rank"));
+            v2_result.put("nearest_taxon_mrca_unique_name", nearest.get("unique_name"));
             // this relies on our kludgey node id representation!
-            res.put("nearest_taxon_mrca_node_id", ottId);
+            v2_result.put("nearest_taxon_mrca_node_id", ottId);
         }
-
-        return OTRepresentationConverter.convert(res);
+        return OTRepresentationConverter.convert(v2_result);
     }
 
     @Description("Return a tree with tips corresponding to the nodes identified in the "
@@ -300,15 +308,25 @@ public class tree_of_life extends ServerPlugin {
 
         */
 
-        Map<String, Object> result = v3.doInducedSubtree(graphDb, longIdsToStringIds(nodeIDs), ottIDs, "name_and_id", Boolean.FALSE);
-        result.put("newick", result.get("newick"));
-        result.put("node_ids_not_in_tree", empty);
-        result.put("node_ids_not_in_graph", empty);
-        result.put("ott_ids_not_in_tree", empty);
-        result.put("ott_ids_not_in_graph", empty);
-        result.put("tree_id", treeId);
+        Map<String, Object> v2_result = new HashMap<>(); // the result we're returning
+        Map<String, Object> v3_result; // the result returned by the v3 method
+        try {
+            v3_result = v3.doInducedSubtree(graphDb, longIdsToStringIds(nodeIDs), ottIDs, "name_and_id", Boolean.FALSE);
+            v2_result.put("node_ids_not_in_tree", empty);
+            v2_result.put("ott_ids_not_in_tree", empty);
+        } catch (BadIdsException e) {
+            v3_result = e.json;
+            v2_result.put("node_ids_not_in_tree", stringIdsToLongIds(e.nodeIds));
+            v2_result.put("ott_ids_not_in_tree", e.ottIds);
+        }
 
-        return OTRepresentationConverter.convert(result);
+        v2_result.put("newick", v3_result.get("newick"));
+
+        v2_result.put("node_ids_not_in_graph", empty);
+        v2_result.put("ott_ids_not_in_graph", empty);
+        v2_result.put("tree_id", treeId);
+
+        return OTRepresentationConverter.convert(v2_result);
     }
 
     
@@ -380,7 +398,6 @@ public class tree_of_life extends ServerPlugin {
         return newNodeIDs;
     }
 
-
     public static long stringIdToLongId(String id) {
         if (id.startsWith("ott"))
             return Long.parseLong(id.substring(3));
@@ -392,4 +409,15 @@ public class tree_of_life extends ServerPlugin {
         } else
             return -1;
     }
+
+    public static List<Long> stringIdsToLongIds(List<String> ids) {
+        if (ids == null) return empty;
+        List<Long> newNodeIDs = new ArrayList<Long>();
+        for (String id : ids)
+            newNodeIDs.add(stringIdToLongId(id));
+        return newNodeIDs;
+    }
+
+
+
 }

--- a/src/main/java/opentree/plugins/tree_of_life.java
+++ b/src/main/java/opentree/plugins/tree_of_life.java
@@ -238,14 +238,17 @@ public class tree_of_life extends ServerPlugin {
                 v2_result.put("mrca_unique_name", "");
             else
                 v2_result.put("mrca_unique_name", uname);
-            v2_result.put("nearest_taxon_mrca_node_id", nodeId);
+            v2_result.put("nearest_taxon_mrca_node_id", stringIdToLongId(nodeId));
         } else {
             v2_result.put("ott_id", "null");
             v2_result.put("mrca_name", "");
             v2_result.put("mrca_rank", "");
             v2_result.put("mrca_unique_name", "");
         }
-        if (nearest != null) {
+        // Not sure what the old v2 API did in this situation, I think
+        // it just put random values, or no values at all
+        if (nearest == null) nearest = taxon;
+        {
             // What's in all these fields when nearest_taxon == taxon ?
             Object ottId = nearest.get("ott_id");
             v2_result.put("nearest_taxon_mrca_ott_id", ottId);

--- a/src/main/java/opentree/plugins/tree_of_life_v3.java
+++ b/src/main/java/opentree/plugins/tree_of_life_v3.java
@@ -326,38 +326,38 @@ public class tree_of_life_v3 extends ServerPlugin {
                 }
             }
         }
-        
-        if (!ottIdsNotInTree.isEmpty() || !nodesIDsNotInTree.isEmpty()) {
-            throw new BadInputException(multipleBadNodeIDsError(ottIdsNotInTree, nodesIDsNotInTree));
-        } else {
-            HashMap<String, Object> res = new HashMap<>();
-            Node mrca = ge.getDraftTreeMRCA(tips, synthTreeID);
-            HashSet<String> uniqueSources = new HashSet<>();
-            
-            HashMap<String, Object> mrcaInfo = ge.getNodeBlob(mrca, synthTreeID, uniqueSources);
-            res.put("mrca", mrcaInfo);
-            HashMap<String, Object> sourceMap = ge.getSourceIDMap(uniqueSources, synthTreeID);
-            //nodeIfo.put("synth_id", synthTreeID);
-            res.put("source_id_map", sourceMap);
-            
-            if (!ottIdsNotInTree.isEmpty()) {
-                res.put("ott_ids_not_in_tree", ottIdsNotInTree);
-            }
-            if (!nodesIDsNotInTree.isEmpty()) {
-                res.put("node_ids_not_in_tree", nodesIDsNotInTree);
-            }
-            
-            // now find the most recent taxonomic ancestor (in tree), if mrca is not a taxon
-            if (!mrca.hasProperty("name")) {
-                Node mrta = ge.getDraftTreeMRTA(mrca, synthTreeID);
 
-                HashMap<String, Object> mrtaInfo = ge.getTaxonBlob(mrta);
-                res.put("nearest_taxon", mrtaInfo);
-            }
-            
-            ge.shutdownDB();
-            return res;
+        HashMap<String, Object> res = new HashMap<>();
+        Node mrca = ge.getDraftTreeMRCA(tips, synthTreeID);
+        HashSet<String> uniqueSources = new HashSet<>();
+
+        HashMap<String, Object> mrcaInfo = ge.getNodeBlob(mrca, synthTreeID, uniqueSources);
+        res.put("mrca", mrcaInfo);
+        HashMap<String, Object> sourceMap = ge.getSourceIDMap(uniqueSources, synthTreeID);
+        //nodeIfo.put("synth_id", synthTreeID);
+        res.put("source_id_map", sourceMap);
+
+        if (!ottIdsNotInTree.isEmpty()) {
+            res.put("ott_ids_not_in_tree", ottIdsNotInTree);
         }
+        if (!nodesIDsNotInTree.isEmpty()) {
+            res.put("node_ids_not_in_tree", nodesIDsNotInTree);
+        }
+
+        // now find the most recent taxonomic ancestor (in tree), if mrca is not a taxon
+        if (!mrca.hasProperty("name")) {
+            Node mrta = ge.getDraftTreeMRTA(mrca, synthTreeID);
+
+            HashMap<String, Object> mrtaInfo = ge.getTaxonBlob(mrta);
+            res.put("nearest_taxon", mrtaInfo);
+        }
+
+        ge.shutdownDB();
+
+        if (!ottIdsNotInTree.isEmpty() || !nodesIDsNotInTree.isEmpty())
+            throw new BadIdsException(ottIdsNotInTree, nodesIDsNotInTree, res);
+
+        return res;
     }
     
     
@@ -490,28 +490,25 @@ public class tree_of_life_v3 extends ServerPlugin {
             }
         }
         
-        if (!ottIdsNotInTree.isEmpty() || !nodesIDsNotInTree.isEmpty()) {
-            throw new BadInputException(multipleBadNodeIDsError(ottIdsNotInTree, nodesIDsNotInTree));
-        }
-        
         if (tips.size() < 2) {
             String ret = "Not enough valid node ids provided to construct a subtree "
                 + "(there must be at least two).";
             throw new BadInputException(ret);
-        } else {
-            HashMap<String, Object> res = new HashMap<>();
-            
-            //res.put("synth_id", synthTreeID);
-            if (!ottIdsNotInTree.isEmpty()) {
-                res.put("ott_ids_not_in_tree", ottIdsNotInTree);
-            }
-            if (!nodesIDsNotInTree.isEmpty()) {
-                res.put("node_ids_not_in_tree", nodesIDsNotInTree);
-            }
-            
-            res.put("newick", ge.getInducedSubtree(tips, synthTreeID, labelFormat, idsForUnnamed).getNewick(false) + ";");
-            return res;
         }
+        HashMap<String, Object> res = new HashMap<>();
+            
+        //res.put("synth_id", synthTreeID);
+        if (!ottIdsNotInTree.isEmpty()) {
+            res.put("ott_ids_not_in_tree", ottIdsNotInTree);
+        }
+        if (!nodesIDsNotInTree.isEmpty()) {
+            res.put("node_ids_not_in_tree", nodesIDsNotInTree);
+        }
+        res.put("newick", ge.getInducedSubtree(tips, synthTreeID, labelFormat, idsForUnnamed).getNewick(false) + ";");
+            
+        if (!ottIdsNotInTree.isEmpty() || !nodesIDsNotInTree.isEmpty())
+            throw new BadIdsException(ottIdsNotInTree, nodesIDsNotInTree, res);
+        return res;
     }
     
     
@@ -726,13 +723,13 @@ public class tree_of_life_v3 extends ServerPlugin {
     }
     
     private String badOTTIDError (Long ottID) {
-        String ret = "Could not find any graph nodes corresponding to the OTT id provided ("
+        String ret = "Could not find any synthetic tree nodes corresponding to the OTT id provided ("
             + ottID + ").";
         return ret;
     }
     
     private String badNodeIDError (String nodeID) {
-        String ret = "Could not find any graph nodes corresponding to the node id provided ("
+        String ret = "Could not find any synthetic tree nodes corresponding to the node id provided ("
             + nodeID + ").";
         return ret;
     }

--- a/ws-tests/check.py
+++ b/ws-tests/check.py
@@ -17,6 +17,7 @@ def simple_test(path, input, check=None, expected_status=200, is_right=(lambda x
                                               return_bool_data=True)
         if not win:
             # Error message already printed
+            print '** http lose'
             return 1
         if isinstance(output, dict) and 'error' in output:
             # Should be 400, not 200

--- a/ws-tests/opentreetesting.py
+++ b/ws-tests/opentreetesting.py
@@ -220,7 +220,7 @@ def exit_if_api_is_readonly(fn):
 
 
 # Mimic the behavior of apache so that services can be tested without
-# having apache running.  See opentree/deploy/setup/opentree-shared.conf
+# having apache running.  See germinator/deploy/setup/opentree-shared.conf
 
 translations = [('/v2/study/', '/phylesystem/v1/study/'),
                 ('/cached/', '/phylesystem/default/cached/'),

--- a/ws-tests/test_v2_mrca_no_400.py
+++ b/ws-tests/test_v2_mrca_no_400.py
@@ -1,0 +1,40 @@
+import sys
+from check import *
+
+def check_ottid_or_null(x, where):
+    if x == u'null':
+        return True
+    elif check_integer(x, where):
+        return True
+    else:
+        print '** expected OTT id or "null", but got', x, where
+        return False
+
+mrca_result_fields = [field(u'mrca_node_id', check_integer),
+                      field(u'invalid_node_ids', check_list(check_integer)),
+                      field(u'invalid_ott_ids', check_list(check_integer)),
+                      field(u'node_ids_not_in_tree', check_list(check_integer)),
+                      field(u'ott_ids_not_in_tree', check_list(check_integer)),
+                      field(u'tree_id', check_string),
+                      field(u'ott_id', check_ottid_or_null),
+                      field(u'mrca_name', check_string),
+                      field(u'mrca_rank', check_string),
+                      field(u'mrca_unique_name', check_string), 
+                      field(u'nearest_taxon_mrca_ott_id', check_integer),
+                      field(u'nearest_taxon_mrca_name', check_string),
+                      field(u'nearest_taxon_mrca_rank', check_string),
+                      field(u'nearest_taxon_mrca_unique_name', check_string),
+                      field(u'nearest_taxon_mrca_node_id', check_integer)] 
+
+def is_right(result):
+    return 3 in result[u'ott_ids_not_in_tree']
+
+status = 0
+
+status += \
+simple_test("/v2/tree_of_life/mrca",
+            {u'ott_ids': [1084532, 3826, 2, 3, 5]}, # two families in Asterales, and some bogus
+            check_blob(mrca_result_fields),
+            is_right=is_right)
+
+sys.exit(status)


### PR DESCRIPTION
Bug reported by @hdliv .  When the ott id list in a mrca or induced subtree call contained an unrecognized id, we were getting a 400 response a la v3, breaking his script. Instead, revert to something like v2 behavior: return missing id lists in result. All such ids are considered 'not in tree' rather than 'invalid'.