### PR TITLE
induced_subtree and subtree methods now return supporting_studies list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+
+
+all: compile restart test
+
+PLUGIN=target/treemachine-neo4j-plugins-0.0.1-SNAPSHOT.jar
+SETTINGS=host:apihost=http://localhost:7474 host:translate=true
+
+compile: $(PLUGIN)
+
+SOURCES=$(shell echo `find src -name "*.java"`)
+
+$(PLUGIN): $(SOURCES)
+	./mvn_serverplugins.sh -q
+
+run: .running
+
+.running: $(PLUGIN)
+	rm -f .running
+	neo4j-community-1.9.5/bin/neo4j stop
+	cp -p $(PLUGIN) neo4j-community-1.9.5/plugins/
+	neo4j-community-1.9.5/bin/neo4j start
+	rm -f .not-running
+	touch .running
+
+test-v3: .running
+	cd ws-tests; \
+	for test in test_[^v]*.py; do \
+	  echo $$test; \
+	  python $$test $(SETTINGS); \
+	done 
+
+test-v2: .running
+	cd ws-tests; \
+	for test in test_v2*.py; do \
+	  echo $$test; \
+	  python $$test $(SETTINGS); \
+	done
+
+not-running: .not-running
+.not-running:
+	neo4j-community-1.9.5/bin/neo4j stop
+	rm -f .running
+	touch .not-running
+
+test: test-v2 test-v3

--- a/mvn_cmdline.sh
+++ b/mvn_cmdline.sh
@@ -1,1 +1,1 @@
-mvn clean compile assembly:single
+mvn $* clean compile assembly:single

--- a/mvn_serverplugins.sh
+++ b/mvn_serverplugins.sh
@@ -1,1 +1,1 @@
-mvn -f pom.serverplugins.xml clean compile package jar:jar
+mvn $* -f pom.serverplugins.xml clean compile package jar:jar

--- a/src/main/java/opentree/GraphExplorer.java
+++ b/src/main/java/opentree/GraphExplorer.java
@@ -701,7 +701,7 @@ public class GraphExplorer extends GraphBase {
      * @param labelFormat valid label formats are: `name`, `id`, or `name_and_id`
      * @return root the root of the constructed JadeTree
      */
-    public JadeNode getInducedSubtree (List<Node> nodeset, String treeID, String labelFormat, boolean idsForUnnamed) {
+    public JadeTree getInducedSubtree (List<Node> nodeset, String treeID, String labelFormat, boolean idsForUnnamed) {
         
         if (nodeset.size() < 2) {
             throw new UnsupportedOperationException("Cannot extract a tree with < 2 tips.");
@@ -756,7 +756,7 @@ public class GraphExplorer extends GraphBase {
         HashSet<Node> addedNodes = new HashSet<>();
         
         JadeNode root = new JadeNode(); // add names, etc.
-        root.assocObject("graphNode", mrca);
+        root.assocObject("graph_node", mrca);
         
         root.setName(getNodeLabel(mrca, labelFormat, idsForUnnamed));
         addedNodes.add(mrca); // collect processed graph nodes
@@ -770,7 +770,7 @@ public class GraphExplorer extends GraphBase {
                 Node workingGraphNode = futureTreeNodes.get(i);
                 if (!addedNodes.contains(workingGraphNode)) { // skip existing nodes
                     JadeNode childTreeNode = new JadeNode();
-                    childTreeNode.assocObject("graphNode", workingGraphNode);
+                    childTreeNode.assocObject("graph_node", workingGraphNode);
                     childTreeNode.setName(getNodeLabel(workingGraphNode, labelFormat, idsForUnnamed));
                     // add child node to current parent
                     JadeNode parent = graphNodeTreeNodeMap.get(curGraphParent);
@@ -781,7 +781,7 @@ public class GraphExplorer extends GraphBase {
                 curGraphParent = workingGraphNode;
             }
         }
-        return root;
+        return new JadeTree(root);
     }
     
     

--- a/src/main/java/opentree/GraphExplorer.java
+++ b/src/main/java/opentree/GraphExplorer.java
@@ -344,7 +344,7 @@ public class GraphExplorer extends GraphBase {
         HashSet<String> uniqueSources = new HashSet<>();
         JadeTree tree = reconstructDepthLimitedSubtree(treeID, startNode, maxDepth, "id");
         JadeNode root = tree.getRoot();
-        root.assocObject("graph_node", startNode);
+        // root.assocObject("graph_node", startNode);
         results = processArgusonTree(root, treeID, uniqueSources);
         LinkedList<HashMap<String, Object>> lineage = getLineageArguson(startNode, treeID, uniqueSources);
         results.put("lineage", lineage);
@@ -353,7 +353,52 @@ public class GraphExplorer extends GraphBase {
         return results;
     }
     
+    // Get study ids for all supported_by annotations for all nodes in jade tree
+
+    public Set<String> getSupportingStudies(JadeTree tree, String treeID) {
+        JadeNode root = tree.getRoot();
+        // root.assocObject("graph_node", startNode);
+        Set<String> studies = new HashSet<String>();
+        getSupportingStudies(root, treeID, studies);
+        return studies;
+    }
+
+    public void getSupportingStudies(JadeNode inNode, String treeID, Set<String> studies) {
+        Node gNode = (Node) inNode.getObject("graph_node"); // neo4j node
+        if (gNode == null)
+            throw new RuntimeException("no graph_node for jade node");
+        getSupportingStudies(gNode, treeID, studies);       // find study ids
+        int count = inNode.getChildCount();
+        for (int i = 0; i < count; ++i)
+            getSupportingStudies(inNode.getChild(i), treeID, studies);
+    }
+
+    // Get study ids for all supported_by annotations for this node
+
+    public void getSupportingStudies (Node curNode, String treeID, Set<String> studies) {
+        if (curNode.hasRelationship(RelType.SYNTHCHILDOF, Direction.OUTGOING)) {
+            for (Relationship rel : curNode.getRelationships(RelType.SYNTHCHILDOF, Direction.OUTGOING)) {
+                if (String.valueOf(rel.getProperty("name")).equals(treeID)) {
+                    // crude to use getPropertyKeys() here, but I don't want to learn what the correct method is!
+                    for (String key : rel.getPropertyKeys()) {
+                        if (key.equals("supported_by")) {
+                            HashMap<String, String> mapProp = stringToMap((String) rel.getProperty(key));
+                            // maps "studyid@treeid" to "nodeid"
+                            for (String source : mapProp.keySet()) {
+                                HashMap<String, String> res =
+                                    stringToMap((String) getSourceMapNodeByName(treeID).getProperty(source));
+                                String id = res.get("study_id");
+                                if (id != null && !id.equals("null"))  // don't know what this is about
+                                    studies.add(id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     
+
     // like getLineage above, but need extra stuff for arguson
     public LinkedList<HashMap<String, Object>> getLineageArguson (Node nd, String treeID, HashSet<String> uniqueSources) {
         LinkedList<HashMap<String, Object>> lineage = new LinkedList<>();
@@ -523,6 +568,7 @@ public class GraphExplorer extends GraphBase {
                 }
             }
         }
+        root.assocObject("graph_node", rootnode); // JAR
         JadeTree tree = new JadeTree(root);
         return tree;
     }

--- a/src/main/java/opentree/plugins/tree_of_life_v3.java
+++ b/src/main/java/opentree/plugins/tree_of_life_v3.java
@@ -1,5 +1,7 @@
 package opentree.plugins;
 
+import java.util.Set;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -695,6 +697,8 @@ public class tree_of_life_v3 extends ServerPlugin {
             JadeTree tree = null;
             try {
                 tree = ge.reconstructDepthLimitedSubtree(synthTreeID, qNode, newickDepth, labelFormat, idsForUnnamed);
+                Set<String> studies = ge.getSupportingStudies(tree, synthTreeID);
+                responseMap.put("supporting_studies", new ArrayList<String>(studies));
             } finally {
                 ge.shutdownDB();
             }

--- a/src/main/java/opentree/plugins/tree_of_life_v3.java
+++ b/src/main/java/opentree/plugins/tree_of_life_v3.java
@@ -506,8 +506,12 @@ public class tree_of_life_v3 extends ServerPlugin {
         if (!nodesIDsNotInTree.isEmpty()) {
             res.put("node_ids_not_in_tree", nodesIDsNotInTree);
         }
-        res.put("newick", ge.getInducedSubtree(tips, synthTreeID, labelFormat, idsForUnnamed).getNewick(false) + ";");
-            
+        JadeTree induced = ge.getInducedSubtree(tips, synthTreeID, labelFormat, idsForUnnamed);
+        res.put("newick", induced.getRoot().getNewick(false) + ";");
+
+        Set<String> studies = ge.getSupportingStudies(induced, synthTreeID);
+        res.put("supporting_studies", new ArrayList<String>(studies));
+
         if (!ottIdsNotInTree.isEmpty() || !nodesIDsNotInTree.isEmpty())
             throw new BadIdsException(ottIdsNotInTree, nodesIDsNotInTree, res);
         return res;

--- a/ws-tests/test_induced_subtree.py
+++ b/ws-tests/test_induced_subtree.py
@@ -6,7 +6,8 @@ status = 0
 status += \
 simple_test("/v3/tree_of_life/induced_subtree",
             {u'node_ids': [u"ott3504", u"ott396446"]},
-            check_blob([field(u'newick', check_string)]))
+            check_blob([field(u'newick', check_string),
+                        field(u'supporting_studies', check_list(check_string))]))
 
 # test that includes ottids that aren't in tree
 status += \

--- a/ws-tests/test_subtree.py
+++ b/ws-tests/test_subtree.py
@@ -3,22 +3,25 @@ from check import *
 
 status = 0
 
+check_newick_result = check_blob([field(u'newick', check_string),
+                                  field(u'supporting_studies', check_list(check_string))])
+
 status += \
 simple_test("/v3/tree_of_life/subtree",
             {u'node_id': u"ott3504"},
-            check_blob([field(u'newick', check_string)]))
+            check_newick_result)
 
 # Test that default is no mrca labels
 # 217260 = Cebus
 simple_test("/v3/tree_of_life/subtree",
             {u'node_id': u'ott217260'},
-            check_blob([field(u'newick', check_string)]),
+            check_newick_result,
             is_right=lambda x: not (u'mrca' in x[u'newick']))
 
 # Test ability to generate mrca labels
 simple_test("/v3/tree_of_life/subtree",
             {u'node_id': u'ott217260', u'include_all_node_labels': True},
-            check_blob([field(u'newick', check_string)]),
+            check_newick_result,
             is_right=lambda x: u'mrca' in x[u'newick'])
 
 status += \

--- a/ws-tests/test_v2_subtree.py
+++ b/ws-tests/test_v2_subtree.py
@@ -2,6 +2,7 @@ import sys
 from check import *
 
 subtree_result_fields = [field(u'newick', check_string),
+                         field(u'supporting_studies', check_list(check_string)),
                          field(u'tree_id', check_string)] 
 
 status = 0


### PR DESCRIPTION
Partially addresses #163. For a complete answer we should have a companion oti method that returns the reference strings and DOIs, given a list of study ids.

    $ curl -H "content-type:application/json" -X POST https://devapi.opentreeoflife.org/v3/tree_of_life/induced_subtree -d '{"ott_ids":[292466, 267845, 666104, 316878, 102710]}'
    {
      "supporting_studies" : [ "pg_2404", "pg_2577", "pg_420", "pg_2591" ],
      "newick" : "(((Cinclus_ott267845,Setophaga_ott666104),(Perdix_ott102710,Clangula_ott316878)Galloanserae_ott5839486)Neognathae_ott241846,Struthio_ott292466)Aves_ott81461;"
